### PR TITLE
Get timestamp Class using PersistentEntity rather than MetaClass

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -4,11 +4,10 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://repo.grails.org/grails/core" }
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:latest.release"
     }
 }
 
@@ -16,6 +15,7 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.2.0'
     id "org.asciidoctor.jvm.pdf" version "3.2.0"
     id "org.asciidoctor.jvm.epub" version "3.2.0"
+    id "com.jfrog.artifactory" version "4.21.0"
 }
 
 version project.file("../version.txt").text.trim()
@@ -26,7 +26,6 @@ apply plugin: "idea"
 apply plugin: "org.grails.grails-plugin"
 apply plugin: "org.grails.grails-plugin-publish"
 apply plugin: "org.grails.grails-gsp"
-apply plugin: "com.jfrog.artifactory"
 
 ext {
     grailsVersion = project.grailsVersion
@@ -61,7 +60,7 @@ dependencies {
     provided "org.grails:grails-plugin-services"
     provided "org.grails:grails-plugin-domain-class"
 
-    testCompile "org.grails:grails-plugin-testing"
+    testCompile "org.grails:grails-gorm-testing-support"
     testCompile "org.grails:grails-web-testing-support"
 }
 


### PR DESCRIPTION
I struck a problem while upgrading a project to Grails 4.0.10 where the `metaClass.hasProperty` mechanism used previously seems to always return `null`. I think the timestamps were actually being set by some other Grails/GORM mechanism. With Grails 4.0.10 I started getting errors where it was trying to insert null into the not-null `date_created` column.

The change I'm proposing uses the GORM `PersistentEntity` for the domain class to find the datatype of the timestamp properties, which is more akin to what Grails/GORM does.

The changes in `build.gradle` are what I had to do to get the project to build locally, I don't know if they're necessary in all environments.