### PR TITLE
Added 2 new properties: includePackages and excludePackages.

### DIFF
--- a/examples/audit-test/grails-app/conf/application.groovy
+++ b/examples/audit-test/grails-app/conf/application.groovy
@@ -11,6 +11,8 @@ grails {
             useDatasource = 'second' // store in "second" datasource
             replacementPatterns = ["a.b": ""]
             truncateLength = 1000000
+            includePackages = [ 'test', 'other.one' ]
+            excludePackages = [ 'not.this.package', 'or.this.one' ]
         }
     }
 }

--- a/examples/audit-test/src/integration-test/groovy/test/AuditableSpec.groovy
+++ b/examples/audit-test/src/integration-test/groovy/test/AuditableSpec.groovy
@@ -22,6 +22,22 @@ class AuditableSpec extends Specification {
         entity = new TestEntity(property: 'foo')
     }
 
+    void "includePackages are respected"() {
+        expect:
+        !AuditLogContext.withConfig(includePackages: ['p1', 'p2']) { entity.isAuditable(AuditEventType.INSERT) }
+        AuditLogContext.withConfig(includePackages: ['test', 'p2']) { entity.isAuditable(AuditEventType.INSERT) }
+        AuditLogContext.withConfig(includePackages: []) { entity.isAuditable(AuditEventType.INSERT) }
+        AuditLogContext.withConfig([:]) { entity.isAuditable(AuditEventType.INSERT) }
+    }
+
+    void "excludePackages are respected"() {
+        expect:
+        AuditLogContext.withConfig(excludePackages: ['p1', 'p2']) { entity.isAuditable(AuditEventType.INSERT) }
+        !AuditLogContext.withConfig(excludePackages: ['test', 'p2']) { entity.isAuditable(AuditEventType.INSERT) }
+        AuditLogContext.withConfig(excludePackages: []) { entity.isAuditable(AuditEventType.INSERT) }
+        AuditLogContext.withConfig([:]) { entity.isAuditable(AuditEventType.INSERT) }
+    }
+
     void "excluded properties are respected"() {
         expect:
         AuditLogContext.withConfig(excluded: ['p1', 'p2']) { entity.getLogExcluded() } == ['p1', 'p2'] as Set<String>

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/Auditable.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/Auditable.groovy
@@ -27,6 +27,16 @@ trait Auditable {
      */
     @Transient
     boolean isAuditable(AuditEventType eventType) {
+        List<String> includePackages = AuditLogContext.context.includePackages as List<String>
+        if (includePackages && !includePackages.any { this.class.name.startsWith(it + ".") }) {
+            return false
+        }
+
+        List<String> excludePackages = AuditLogContext.context.excludePackages as List<String>
+        if (excludePackages && excludePackages.any { this.class.name.startsWith(it + ".") }) {
+            return false
+        }
+
         true
     }
 


### PR DESCRIPTION
The company that I work for has a use case in which we have the audit-logging plugin in project X, but we also import other `Auditable` entities from a different JAR that should not be audited in project X. I thought that the addition of 2 new properties `includePackages` and `excludePackages` would be a good and simple solution in this case. We depend on a solution for this use case in other to use the audit-logging plugin in project X. Thank you!