### PR TITLE
Fix createdBy and lastUpdatedBy was not write to domain correctly on …

### DIFF
--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/StampListener.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/StampListener.groovy
@@ -23,6 +23,7 @@ import grails.plugins.orm.auditable.resolvers.AuditRequestResolver
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.grails.datastore.mapping.core.Datastore
+import org.grails.datastore.mapping.engine.EntityAccess
 import org.grails.datastore.mapping.engine.event.AbstractPersistenceEvent
 import org.grails.datastore.mapping.engine.event.AbstractPersistenceEventListener
 import org.grails.datastore.mapping.engine.event.EventType
@@ -60,7 +61,6 @@ class StampListener extends AbstractPersistenceEventListener {
         }
 
         try {
-            Stampable domain = event.entityObject as Stampable
             log.trace("Stamping object {}", event.entityObject.class.name)
 
             // Lookup the request resolver here to ensure that applications have a chance
@@ -69,10 +69,10 @@ class StampListener extends AbstractPersistenceEventListener {
 
             switch(event.eventType) {
                 case EventType.PreInsert:
-                    handleInsert(domain, requestResolver)
+                    handleInsert(event.entityAccess, requestResolver)
                     break
                 case EventType.PreUpdate:
-                    handleUpdate(domain, requestResolver)
+                    handleUpdate(event.entityAccess, requestResolver)
                     break
             }
         }
@@ -94,17 +94,17 @@ class StampListener extends AbstractPersistenceEventListener {
     /**
      * Stamp inserts
      */
-    protected void handleInsert(Stampable domain, AuditRequestResolver requestResolver) {
+    protected void handleInsert(EntityAccess domain, AuditRequestResolver requestResolver) {
         // Set actors, Grails will take care of setting the dates
         String currentActor = requestResolver.currentActor
-        domain.createdBy = currentActor
-        domain.lastUpdatedBy = currentActor
+        domain.setProperty("createdBy", currentActor)
+        domain.setProperty("lastUpdatedBy", currentActor)
     }
 
     /**
      * Stamp updates
      */
-    protected void handleUpdate(Stampable domain, AuditRequestResolver requestResolver) {
-        domain.lastUpdatedBy = requestResolver.currentActor
+    protected void handleUpdate(EntityAccess domain, AuditRequestResolver requestResolver) {
+        domain.setProperty("lastUpdatedBy", requestResolver.currentActor)
     }
 }


### PR DESCRIPTION
…certain condition

Fix symentis/grails-audit-logging-plugin#224

When the Stampable is inheriting from a super class, for example

1. The super class `WithDynamicFields` implements Stampable
```
abstract class WithDynamicFields<D> implements Auditable, Stampable<D> {

}
```

2. The actual class extends the super class `WithDynamicFields`

```
class Article extends WithDynamicFields<Article> {

}
```

Currently under this condition, createdBy and lastUpdatedBy value saved to database is always 'N/A', it doesn't happen when class `Article` implements `Stampable` directly.

This commit fixes the above issue

It seems the issue is use `entityObject` as parameter of `handleInsert` and `handleUpdate` inside `StampListener` class, then set value of `createdBy` and `lastUpdatedBy` there will not trigger update of `modifiedProperties` inside ModificationTrackingEntityAccess, so hibernate was not aware of those changes, and changes was not commit to database. 

This fix is to set property of `createdBy` and `lastUpdatedBy` using `entityAccess.setProperty` so that hibernate can aware of changes to these two attributes, and they will be commit to database correctly.

